### PR TITLE
feat(fasteth): add support for eth_getLogs

### DIFF
--- a/fasteth/models.py
+++ b/fasteth/models.py
@@ -52,6 +52,7 @@ class RPCSchema(tuple, Enum):
     get_block_transaction_count_by_hash = ("eth_getBlockTransactionCountByHash", 1)
     get_block_transaction_count_by_number = ("eth_getBlockTransactionCountByNumber", 1)
     get_transaction_by_hash = ("eth_getTransactionByHash", 1)
+    get_logs = ("eth_getLogs", 1)
     get_uncle_count_by_block_hash = ("eth_getUncleCountByBlockHash", 1)
     get_uncle_count_by_block_number = ("eth_getUncleCountByBlockNumber", 1)
     get_shh_messages = ("shh_getMessages", 73)
@@ -129,7 +130,10 @@ class JSONRPCRequest(BaseModel):
     id: Uint256
 
     class Config:
-        json_encoders = {bytes: lambda x: f"0x{x.hex()}", Uint256: hex}
+        json_encoders = {
+            bytes: lambda x: f"0x{x.hex()}",
+            Uint256: hex,
+        }
 
 
 class EthereumErrorData(BaseModel):
@@ -278,6 +282,14 @@ class Log(AutoEthable):
     blockHash: ETHWord
     logIndex: Uint256
     removed: bool
+
+
+class LogsFilter(BaseModel):
+    fromBlock: ETHBlockIdentifier | None = None
+    toBlock: ETHBlockIdentifier | None = None
+    address: ETHAddress | list[ETHAddress]
+    topics: list[ETHWord] | None = None
+    blockHash: ETHWord | None = None
 
 
 class TransactionReceipt(AutoEthable):

--- a/fasteth/rpc.py
+++ b/fasteth/rpc.py
@@ -278,6 +278,49 @@ class AsyncEthereumJSONRPC(AsyncJSONRPCCore):
             )
         )
 
+    async def get_logs(self, logs_request: models.LogsFilter) -> list[models.Log]:
+        """Returns an array of all logs matching a given filter object.
+
+        Calls eth_getLogs.
+
+        :param object: a filter object which contains
+        the following fields ->
+            :param fromBlock: a types.ETHBlockIdentifier to
+            specify where to start checking.
+            :param toBlock: a types.ETHBlockIdentifier to
+            specify where to end checking.
+            :param address: The contract address or a list
+            of addresses from which logs should originate from.
+            :param topics: a list[types.ETHWord] to check event
+            topics against.
+            :param blockHash: an types.ETHBlockIdentifier of
+            the block to check in.
+
+        :returns
+            list[models.Log]: A list of logs which sastisfy the filter object.
+        """
+        dict_request = logs_request.dict(exclude_none=True)
+
+        dict_request["fromBlock"] = (
+            hex(dict_request["fromBlock"])
+            if isinstance(dict_request["fromBlock"], types.Uint256)
+            else dict_request["fromBlock"]
+        )
+
+        dict_request["toBlock"] = (
+            hex(dict_request["toBlock"])
+            if isinstance(dict_request["toBlock"], types.Uint256)
+            else dict_request["toBlock"]
+        )
+
+        request = models.JSONRPCRequest(
+            method=self.rpc_schema.get_logs[0],
+            id=self.rpc_schema.get_logs[1],
+            params=[dict_request],
+        )
+
+        return await self.rpc(request)
+
     async def get_balance(
         self,
         address: types.ETHAddress,


### PR DESCRIPTION
This adds support for calling eth_getLogs. Note that json_encoders with Pydantic models do not work. Hence,  necessary transformation was performed in get_logs.